### PR TITLE
fix: Replace deprecated devise_error_messages!

### DIFF
--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,6 +1,6 @@
 %h2 Resend confirmation instructions
 = form_for(resource, :as => resource_name, :url => confirmation_path(resource_name), :html => { :method => :post }) do |f|
-  = devise_error_messages!
+  = render "devise/shared/devise_error_messages"
   %div
     = f.label :email
     %br

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,6 +1,6 @@
 %h2 Change your password
 = form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put }) do |f|
-  = devise_error_messages!
+  = render "devise/shared/devise_error_messages"
   = f.hidden_field :reset_password_token
   %div
     = f.label :password, "New password"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,6 +1,6 @@
 %h2 パスワードを忘れた
 = form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post }) do |f|
-  = devise_error_messages!
+  = render "devise/shared/devise_error_messages"
   %div
     = f.label "メールアドレス"
     %br

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,7 +1,7 @@
 %h2
   Edit #{resource_name.to_s.humanize}
 = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = devise_error_messages!
+  = render 'devise/shared/devise_error_messages'
   %div
     = f.label :email
     %br

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,6 +1,6 @@
 %h2 Sign up
 = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-  = devise_error_messages!
+  = render 'devise/shared/devise_error_messages'
   %div
     = f.label :email
     %br

--- a/app/views/devise/shared/_devise_error_messages.html.haml
+++ b/app/views/devise/shared/_devise_error_messages.html.haml
@@ -1,0 +1,10 @@
+- if resource.errors.any?
+  #error_explanation
+    %h2
+      = pluralize(resource.errors.count, "error")
+      prohibited this
+      = resource_name.to_s.humanize.downcase
+      from being saved:
+    %ul
+      - resource.errors.full_messages.each do |message|
+        %li= message

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -1,6 +1,6 @@
 %h2 Resend unlock instructions
 = form_for(resource, :as => resource_name, :url => unlock_path(resource_name), :html => { :method => :post }) do |f|
-  = devise_error_messages!
+  = render "devise/shared/devise_error_messages"
   %div
     = f.label :email
     %br

--- a/app/views/devise_registrations/edit.html.haml
+++ b/app/views/devise_registrations/edit.html.haml
@@ -1,7 +1,7 @@
 %h2
   Edit #{resource_name.to_s.humanize}
 = form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put }) do |f|
-  = devise_error_messages!
+  = render "devise/shared/devise_error_messages"
   %div
     = f.label :email
     %br

--- a/app/views/devise_registrations/new.html.haml
+++ b/app/views/devise_registrations/new.html.haml
@@ -1,6 +1,6 @@
 %h2 登録
 = form_for(resource, :as => resource_name, :url => registration_path(resource_name)) do |f|
-  = devise_error_messages!
+  = render "devise/shared/devise_error_messages"
   %div
     = f.label :email
     %br


### PR DESCRIPTION
## Problem
`devise_error_messages!` method was removed in Devise 4.8.0, causing ActionView::Template::Error

## Solution
- Create shared partial `_devise_error_messages.html.haml` to display validation errors
- Replace all `devise_error_messages!` calls with the custom partial
- Covers all Devise view templates (registrations, passwords, confirmations, unlocks)

## Testing
- All 54 existing tests pass
- 0 failures, 0 errors